### PR TITLE
More generic config, example C++ file

### DIFF
--- a/.devcontainer.json
+++ b/.devcontainer.json
@@ -1,12 +1,16 @@
 {
-    "name": "mattovanLinuxMachine",
+    // https://containers.dev/implementors/json_reference/
+    "name": "csslab-container",
     "image": "cssimages/csslab:latest",
     "build": {
-        "context": ".."
+        // The Docker build runs in this path.
+        "context": "${localWorkspaceFolder}"
     },
-    "workspaceMount": "source=${localWorkspaceFolder},target=/home/cssuwbstudent/mattovan/${localWorkspaceFolderBasename},type=bind",
-    "workspaceFolder": "/home/cssuwbstudent/mattovan/${localWorkspaceFolderBasename}",
-    "containerUser": "root",
+    // Bind-mount this workspace from your local OS filesystem into the container's filesystem.
+    // File changes in the workspace will be kept in sync between your local OS and the container.
+    "workspaceMount": "source=${localWorkspaceFolder},target=/home/cssuwbstudent/${localWorkspaceFolderBasename},type=bind",
+    // Where VS Code starts inside the container and expects the workspace folder.
+    "workspaceFolder": "/home/cssuwbstudent/${localWorkspaceFolderBasename}",
     "customizations": {
         "vscode": {
             // Add the IDs of extensions you want installed when the container is created.

--- a/.gitconfig
+++ b/.gitconfig
@@ -1,0 +1,10 @@
+# https://git-scm.com/docs/git-config#_example
+
+[core]
+    # Prevent Git for Windows from "helpfully" converting LF to CRLF
+    # when checking out files. core.autocrlf would otherwise override
+    # the core.eol settings.
+    autocrlf = false
+    # Force Unix-style LF line endings in this repo. Despite probably
+    # cloning this repo from Windows, we use it in a Linux environment.
+    eol = lf

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+# https://git-scm.com/docs/gitignore
+
+# Compiler output executable
+a.out

--- a/.vscode/c_cpp_properties.json
+++ b/.vscode/c_cpp_properties.json
@@ -6,7 +6,7 @@
                 "${workspaceFolder}/**"
             ],
             "defines": [],
-            "compilerPath": "/usr/bin/gcc",
+            "compilerPath": "/usr/bin/g++",
             "intelliSenseMode": "linux-gcc-x64",
             "cppStandard": "c++11"
         }

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,21 +1,16 @@
 {
-    // Use IntelliSense to learn about possible attributes.
-    // Hover to view descriptions of existing attributes.
-    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    // https://code.visualstudio.com/docs/editor/debugging#_launch-configurations
     "version": "0.2.0",
     "configurations": [
         {
             "name": "gcc build then debug file",
             "type": "cppdbg",
             "request": "launch",
-            "program": "${fileDirname}/a.out",
-            "args": [
-                "test-1.txt",
-                "test-2.txt",
-                "test-3.txt"
-            ],
+            "program": "${workspaceFolder}/a.out",
+            // Pass arguments to the executable: [ "foo", "bar" ] will run './a.out foo bar'.
+            "args": [],
             "stopAtEntry": false,
-            "cwd": "${fileDirname}",
+            "cwd": "${workspaceFolder}",
             "environment": [],
             "externalConsole": false,
             "MIMode": "gdb",
@@ -26,6 +21,7 @@
                     "ignoreFailures": true
                 }
             ],
+            // Custom tasks can be found in .vscode/tasks.json.
             "preLaunchTask": "build",
             "miDebuggerPath": "gdb"
         }

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,4 +1,5 @@
 {
+    // https://code.visualstudio.com/docs/editor/tasks#_custom-tasks
     "version": "2.0.0",
     "tasks": [
         {
@@ -14,7 +15,7 @@
                 "*.cpp"
             ],
             "options": {
-                "cwd": "${fileDirname}"
+                "cwd": "${workspaceFolder}"
             },
             "problemMatcher": ["$gcc"],
             "group": {

--- a/main.cpp
+++ b/main.cpp
@@ -1,0 +1,5 @@
+#include <iostream>
+
+int main() {
+    std::cout << "Hello world!" << std::endl;
+}


### PR DESCRIPTION
I made these configs more generic for all users.

The `cssimages/csslab:latest` docker image doesn't actually ship with NetID-specific usernames - it instead comes with the generic user `cssuwbstudent`. Instead of using the home directory `/home/cssuwbstudent/YOURNETID`, it can just be `/home/cssuwbstudent`.

This and other changes make the configs more robust and generic, with some comments. I added a .gitconfig to prevent the whole Windows/Linux CRLF-versus-LF problem.

I even added a generic `main.cpp` example file. Press F5 to build this file and run it in the debugger.